### PR TITLE
fix: calender error handling and moving download button down

### DIFF
--- a/src/pages/Calendar-Page.jsx
+++ b/src/pages/Calendar-Page.jsx
@@ -25,7 +25,7 @@ const CalendarPage = ({ nextStep }) => {
     if (isMobile) {
       const timer = setTimeout(() => {
         setIsTouchDisabled(false);
-      }, 1000); 
+      }, 600); 
 
       return () => clearTimeout(timer); 
     }

--- a/src/pages/DishSelectPage.jsx
+++ b/src/pages/DishSelectPage.jsx
@@ -183,7 +183,7 @@ const DishSelect = ({ backStep }) => {
         })}
       </div>
 
-      <div className="mt-4 flex flex-col items-center gap-4">
+      <div className="mt-10 flex flex-col items-center gap-4">
         <button
           className="bg-textOrange border text-black font-semibold p-2 raleway-font rounded-custom px-20"
           onClick={reactToPrintFunction}

--- a/src/styles/calendar-page.css
+++ b/src/styles/calendar-page.css
@@ -92,3 +92,12 @@
   background-color: #528540 !important; 
   color: white !important;
 }
+
+
+
+@media (max-width: 768px) {
+  .calendar-container.disabled {
+    pointer-events: none; 
+    opacity: 0.5; 
+  }
+}


### PR DESCRIPTION
I added a new error pop-up that is triggered for days between the current day and the start of the selected week. Also fixed the error handling for days chosen in the past. Added an overlay that disables pointer activity for 600ms to calendar on mobile so that user presses create new week  button a day is not selected from calendar prematurely. 